### PR TITLE
Build question & clippy fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ name = "melvin"
 path = "src/lib.rs"
 
 [dependencies]
+devicemapper = { git = "https://github.com/tasleson/devicemapper-rs", branch = "melvin" }
 libc = "*"
 byteorder = "0.3.10"
 crc = "^0.3.1"

--- a/src/lv.rs
+++ b/src/lv.rs
@@ -105,16 +105,16 @@ pub fn to_textmap(lv: &LV, dev_to_idx: &BTreeMap<Device, usize>) -> LvmTextMap {
 
     map.insert(
         "status".to_string(),
-        Entry::List(Box::new(
+        Entry::List(
             lv.status.iter().map(|x| Entry::String(x.clone())).collect(),
-        )),
+        ),
     );
 
     map.insert(
         "flags".to_string(),
-        Entry::List(Box::new(
+        Entry::List(
             lv.flags.iter().map(|x| Entry::String(x.clone())).collect(),
-        )),
+        ),
     );
 
     map.insert(
@@ -252,7 +252,7 @@ pub mod segment {
 
             map.insert(
                 "stripes".to_string(),
-                Entry::List(Box::new(
+                Entry::List(
                     self.stripes
                         .iter()
                         .map(|&(k, v)| {
@@ -261,7 +261,7 @@ pub mod segment {
                         })
                         .flat_map(|x| x)
                         .collect(),
-                )),
+                ),
             );
             map
         }

--- a/src/lv.rs
+++ b/src/lv.rs
@@ -259,7 +259,7 @@ pub mod segment {
                             let name = format!("pv{}", dev_to_idx.get(&k).unwrap());
                             vec![Entry::String(name), Entry::Number(v as i64)].into_iter()
                         })
-                        .flat_map(|x| x)
+                        .flatten()
                         .collect(),
                 ),
             );

--- a/src/lv.rs
+++ b/src/lv.rs
@@ -105,16 +105,12 @@ pub fn to_textmap(lv: &LV, dev_to_idx: &BTreeMap<Device, usize>) -> LvmTextMap {
 
     map.insert(
         "status".to_string(),
-        Entry::List(
-            lv.status.iter().map(|x| Entry::String(x.clone())).collect(),
-        ),
+        Entry::List(lv.status.iter().map(|x| Entry::String(x.clone())).collect()),
     );
 
     map.insert(
         "flags".to_string(),
-        Entry::List(
-            lv.flags.iter().map(|x| Entry::String(x.clone())).collect(),
-        ),
+        Entry::List(lv.flags.iter().map(|x| Entry::String(x.clone())).collect()),
     );
 
     map.insert(

--- a/src/lv.rs
+++ b/src/lv.rs
@@ -60,10 +60,10 @@ pub fn used_areas(lv: &LV) -> Vec<(Device, u64, u64)> {
 pub fn from_textmap(name: &str, map: &LvmTextMap, pvs: &BTreeMap<String, PV>) -> Result<LV> {
     let err = || Error::Io(io::Error::new(Other, "lv textmap parsing error"));
 
-    let id = map.string_from_textmap("id").ok_or(err())?;
-    let creation_host = map.string_from_textmap("creation_host").ok_or(err())?;
-    let creation_time = map.i64_from_textmap("creation_time").ok_or(err())?;
-    let segment_count = map.i64_from_textmap("segment_count").ok_or(err())?;
+    let id = map.string_from_textmap("id").ok_or_else(err)?;
+    let creation_host = map.string_from_textmap("creation_host").ok_or_else(err)?;
+    let creation_time = map.i64_from_textmap("creation_time").ok_or_else(err)?;
+    let segment_count = map.i64_from_textmap("segment_count").ok_or_else(err)?;
 
     let segments: Vec<_> = (0..segment_count)
         .filter_map(|num| {
@@ -78,7 +78,7 @@ pub fn from_textmap(name: &str, map: &LvmTextMap, pvs: &BTreeMap<String, PV>) ->
 
     let flags: Vec<_> = map
         .list_from_textmap("flags")
-        .ok_or(err())?
+        .ok_or_else(err)?
         .iter()
         .filter_map(|item| match item {
             &Entry::String(ref x) => Some(x.clone()),
@@ -201,13 +201,13 @@ pub mod segment {
         ) -> Result<Box<dyn Segment>> {
             let err = || Error::new(Other, "striped segment textmap parsing error");
 
-            let stripe_list = map.list_from_textmap("stripes").ok_or(err())?;
+            let stripe_list = map.list_from_textmap("stripes").ok_or_else(err)?;
 
             let mut stripes = Vec::new();
             for slc in stripe_list.chunks(2) {
                 let dev = match &slc[0] {
-                    &Entry::String(ref x) => {
-                        let pv = pvs.get(x).ok_or(err())?;
+                    Entry::String(ref x) => {
+                        let pv = pvs.get(x).ok_or_else(err)?;
                         pv.device
                     }
                     _ => return Err(err()),
@@ -220,9 +220,9 @@ pub mod segment {
             }
 
             Ok(Box::new(StripedSegment {
-                start_extent: map.i64_from_textmap("start_extent").ok_or(err())? as u64,
-                extent_count: map.i64_from_textmap("extent_count").ok_or(err())? as u64,
-                stripes: stripes,
+                start_extent: map.i64_from_textmap("start_extent").ok_or_else(err)? as u64,
+                extent_count: map.i64_from_textmap("extent_count").ok_or_else(err)? as u64,
+                stripes,
                 // optional
                 stripe_size: map.i64_from_textmap("start_extent").map(|x| x as u64),
             }))
@@ -374,17 +374,17 @@ pub mod segment {
             };
 
             Ok(Box::new(ThinpoolSegment {
-                start_extent: map.i64_from_textmap("start_extent").ok_or(err())? as u64,
-                extent_count: map.i64_from_textmap("extent_count").ok_or(err())? as u64,
+                start_extent: map.i64_from_textmap("start_extent").ok_or_else(err)? as u64,
+                extent_count: map.i64_from_textmap("extent_count").ok_or_else(err)? as u64,
                 metadata_lv: map
                     .string_from_textmap("metadata")
-                    .ok_or(err())?
+                    .ok_or_else(err)?
                     .to_string(),
-                data_lv: map.string_from_textmap("pool").ok_or(err())?.to_string(),
-                transaction_id: map.i64_from_textmap("transaction_id").ok_or(err())? as u64,
-                chunk_size: map.i64_from_textmap("chunk_size").ok_or(err())? as u64,
-                discards: discards,
-                zero_new_blocks: map.i64_from_textmap("start_extent").ok_or(err())? != 0,
+                data_lv: map.string_from_textmap("pool").ok_or_else(err)?.to_string(),
+                transaction_id: map.i64_from_textmap("transaction_id").ok_or_else(err)? as u64,
+                chunk_size: map.i64_from_textmap("chunk_size").ok_or_else(err)? as u64,
+                discards,
+                zero_new_blocks: map.i64_from_textmap("start_extent").ok_or_else(err)? != 0,
             }))
         }
     }
@@ -497,14 +497,14 @@ pub mod segment {
             let err = || Error::new(Other, "thin segment textmap parsing error");
 
             Ok(Box::new(ThinSegment {
-                start_extent: map.i64_from_textmap("start_extent").ok_or(err())? as u64,
-                extent_count: map.i64_from_textmap("extent_count").ok_or(err())? as u64,
+                start_extent: map.i64_from_textmap("start_extent").ok_or_else(err)? as u64,
+                extent_count: map.i64_from_textmap("extent_count").ok_or_else(err)? as u64,
                 thin_pool: map
                     .string_from_textmap("thin_pool")
-                    .ok_or(err())?
+                    .ok_or_else(err)?
                     .to_string(),
-                transaction_id: map.i64_from_textmap("transaction_id").ok_or(err())? as u64,
-                device_id: map.i64_from_textmap("device_id").ok_or(err())? as u64,
+                transaction_id: map.i64_from_textmap("transaction_id").ok_or_else(err)? as u64,
+                device_id: map.i64_from_textmap("device_id").ok_or_else(err)? as u64,
             }))
         }
     }

--- a/src/lv.rs
+++ b/src/lv.rs
@@ -81,7 +81,7 @@ pub fn from_textmap(name: &str, map: &LvmTextMap, pvs: &BTreeMap<String, PV>) ->
         .ok_or_else(err)?
         .iter()
         .filter_map(|item| match item {
-            &Entry::String(ref x) => Some(x.clone()),
+            Entry::String(ref x) => Some(x.clone()),
             _ => None,
         })
         .collect();

--- a/src/lv.rs
+++ b/src/lv.rs
@@ -89,11 +89,11 @@ pub fn from_textmap(name: &str, map: &LvmTextMap, pvs: &BTreeMap<String, PV>) ->
     Ok(LV {
         name: name.to_string(),
         id: id.to_string(),
-        status: status,
-        flags: flags,
+        status,
+        flags,
         creation_host: creation_host.to_string(),
-        creation_time: creation_time,
-        segments: segments,
+        creation_time,
+        segments,
         device: None,
     })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,9 @@ fn get_first_vg_meta() -> Result<(String, parser::LvmTextMap)> {
         // Find the textmap for the vg, among all the other stuff.
         // (It's the only textmap.)
         for (key, value) in map {
-            if let parser::Entry::TextMap(x) = value { return Ok((key, *x)) }
+            if let parser::Entry::TextMap(x) = value {
+                return Ok((key, *x));
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,10 +35,7 @@ fn get_first_vg_meta() -> Result<(String, parser::LvmTextMap)> {
         // Find the textmap for the vg, among all the other stuff.
         // (It's the only textmap.)
         for (key, value) in map {
-            match value {
-                parser::Entry::TextMap(x) => return Ok((key, *x)),
-                _ => {}
-            }
+            if let parser::Entry::TextMap(x) = value { return Ok((key, *x)) }
         }
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -94,7 +94,7 @@ impl<'a> Lexer<'a> {
     /// Returns a new Lexer from a given byte iterator.
     fn new(chars: &'a [u8]) -> Lexer<'a> {
         Lexer {
-            chars: chars,
+            chars,
             next_byte: None,
             cursor: 0,
             next_is_ident: false,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -448,7 +448,7 @@ pub fn status_from_textmap(map: &LvmTextMap) -> Result<Vec<String>> {
         Some(&Entry::List(ref x)) => Ok({
             x.iter()
                 .filter_map(|item| match item {
-                    &Entry::String(ref x) => Some(x.clone()),
+                    Entry::String(ref x) => Some(x.clone()),
                     _ => None,
                 })
                 .collect()
@@ -466,7 +466,7 @@ pub fn textmap_to_buf(tm: &LvmTextMap) -> Vec<u8> {
 
     for (k, v) in tm {
         match v {
-            &Entry::String(ref x) => {
+            Entry::String(ref x) => {
                 vec.extend(k.as_bytes());
                 vec.extend(b" = \"");
                 vec.extend(x.as_bytes());
@@ -483,8 +483,8 @@ pub fn textmap_to_buf(tm: &LvmTextMap) -> Vec<u8> {
                 let z: Vec<_> = x
                     .iter()
                     .map(|x| match x {
-                        &Entry::String(ref x) => format!("\"{}\"", x),
-                        &Entry::Number(ref x) => format!("{}", x),
+                        Entry::String(ref x) => format!("\"{}\"", x),
+                        Entry::Number(ref x) => format!("{}", x),
                         _ => panic!("should not be in lists"),
                     })
                     .collect();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -251,7 +251,7 @@ pub enum Entry {
     /// A text string
     String(String),
     /// An ordered list of strings and numbers, possibly both
-    List(Box<Vec<Entry>>),
+    List(Vec<Entry>),
     /// A nested LvmTextMap
     TextMap(Box<LvmTextMap>),
 }
@@ -395,7 +395,7 @@ fn get_textmap<'a>(tokens: &[Token<'a>]) -> Result<LvmTextMap> {
                             &Token::BracketOpen,
                             &Token::BracketClose,
                         )?;
-                        ret.insert(ident, Entry::List(Box::new(get_list(&slc)?)));
+                        ret.insert(ident, Entry::List(get_list(&slc)?));
                         cur += slc.len();
                     }
                     _ => {

--- a/src/pv.rs
+++ b/src/pv.rs
@@ -21,7 +21,7 @@ pub fn dev_from_textmap(map: &LvmTextMap) -> Result<Device> {
         .ok_or_else(|| Error::Io(io::Error::new(Other, "device textmap parsing error")))?;
 
     let val = match entry {
-        &Entry::String(ref s) => s
+        Entry::String(ref s) => s
             .parse::<i64>()
             .map_err(|_| Error::Io(io::Error::new(Other, "device textmap parsing error")))?,
         &Entry::Number(x) => x,

--- a/src/pv.rs
+++ b/src/pv.rs
@@ -58,7 +58,6 @@ pub struct PV {
 impl PV {
     pub fn path(&self) -> Option<PathBuf> {
         let f = File::open("/proc/partitions")
-            .ok()
             .expect("Could not open /proc/partitions");
 
         let reader = BufReader::new(f);

--- a/src/pv.rs
+++ b/src/pv.rs
@@ -102,9 +102,9 @@ pub fn from_textmap(map: &LvmTextMap) -> Result<PV> {
 
     Ok(PV {
         id: id.to_string(),
-        device: device,
-        status: status,
-        flags: flags,
+        device,
+        status,
+        flags,
         dev_size: dev_size as u64,
         pe_start: pe_start as u64,
         pe_count: pe_count as u64,

--- a/src/pv.rs
+++ b/src/pv.rs
@@ -120,16 +120,16 @@ pub fn to_textmap(pv: &PV) -> LvmTextMap {
 
     map.insert(
         "status".to_string(),
-        Entry::List(Box::new(
+        Entry::List(
             pv.status.iter().map(|x| Entry::String(x.clone())).collect(),
-        )),
+        ),
     );
 
     map.insert(
         "flags".to_string(),
-        Entry::List(Box::new(
+        Entry::List(
             pv.flags.iter().map(|x| Entry::String(x.clone())).collect(),
-        )),
+        ),
     );
 
     map.insert("dev_size".to_string(), Entry::Number(pv.dev_size as i64));

--- a/src/pv.rs
+++ b/src/pv.rs
@@ -82,20 +82,20 @@ impl PV {
 pub fn from_textmap(map: &LvmTextMap) -> Result<PV> {
     let err = || Error::Io(io::Error::new(Other, "pv textmap parsing error"));
 
-    let id = map.string_from_textmap("id").ok_or(err())?;
+    let id = map.string_from_textmap("id").ok_or_else(err)?;
     let device = dev_from_textmap(map)?;
-    let dev_size = map.i64_from_textmap("dev_size").ok_or(err())?;
-    let pe_start = map.i64_from_textmap("pe_start").ok_or(err())?;
-    let pe_count = map.i64_from_textmap("pe_count").ok_or(err())?;
+    let dev_size = map.i64_from_textmap("dev_size").ok_or_else(err)?;
+    let pe_start = map.i64_from_textmap("pe_start").ok_or_else(err)?;
+    let pe_count = map.i64_from_textmap("pe_count").ok_or_else(err)?;
 
     let status = status_from_textmap(map)?;
 
     let flags: Vec<_> = map
         .list_from_textmap("flags")
-        .ok_or(err())?
+        .ok_or_else(err)?
         .iter()
         .filter_map(|item| match item {
-            &Entry::String(ref x) => Some(x.clone()),
+            Entry::String(ref x) => Some(x.clone()),
             _ => None,
         })
         .collect();

--- a/src/pv.rs
+++ b/src/pv.rs
@@ -57,8 +57,7 @@ pub struct PV {
 
 impl PV {
     pub fn path(&self) -> Option<PathBuf> {
-        let f = File::open("/proc/partitions")
-            .expect("Could not open /proc/partitions");
+        let f = File::open("/proc/partitions").expect("Could not open /proc/partitions");
 
         let reader = BufReader::new(f);
 
@@ -119,16 +118,12 @@ pub fn to_textmap(pv: &PV) -> LvmTextMap {
 
     map.insert(
         "status".to_string(),
-        Entry::List(
-            pv.status.iter().map(|x| Entry::String(x.clone())).collect(),
-        ),
+        Entry::List(pv.status.iter().map(|x| Entry::String(x.clone())).collect()),
     );
 
     map.insert(
         "flags".to_string(),
-        Entry::List(
-            pv.flags.iter().map(|x| Entry::String(x.clone())).collect(),
-        ),
+        Entry::List(pv.flags.iter().map(|x| Entry::String(x.clone())).collect()),
     );
 
     map.insert("dev_size".to_string(), Entry::Number(pv.dev_size as i64));

--- a/src/pvlabel.rs
+++ b/src/pvlabel.rs
@@ -87,7 +87,7 @@ impl LabelHeader {
     }
 
     /// Initialize a device with a label header.
-    fn initialize(sec_buf: &mut [u8; SECTOR_SIZE]) -> () {
+    fn initialize(sec_buf: &mut [u8; SECTOR_SIZE]) {
         sec_buf[..8].copy_from_slice(b"LABELONE");
         LittleEndian::write_u64(&mut sec_buf[8..16], LABEL_SECTOR as u64);
         LittleEndian::write_u32(&mut sec_buf[20..24], LABEL_SIZE as u32);

--- a/src/pvlabel.rs
+++ b/src/pvlabel.rs
@@ -35,7 +35,7 @@ use crate::{Error, Result};
 
 const LABEL_SCAN_SECTORS: usize = 4;
 const ID_LEN: usize = 32;
-const MDA_MAGIC: &'static [u8] =
+const MDA_MAGIC: &[u8] =
     b"\x20\x4c\x56\x4d\x32\x20\x78\x5b\x35\x41\x25\x72\x30\x4e\x2a\x3e";
 const LABEL_SIZE: usize = 32;
 const LABEL_SECTOR: usize = 1;

--- a/src/pvlabel.rs
+++ b/src/pvlabel.rs
@@ -255,7 +255,7 @@ impl PvHeader {
 
         let mut buf = [0u8; LABEL_SCAN_SECTORS * SECTOR_SIZE];
 
-        f.read(&mut buf)?;
+        f.read_exact(&mut buf)?;
 
         let label_header = LabelHeader::from_buf(&buf)?;
         let pvheader = Self::from_buf(&buf[label_header.offset as usize..], path)?;
@@ -363,7 +363,7 @@ impl PvHeader {
         LabelHeader::initialize(&mut sec_buf);
 
         f.seek(SeekFrom::Start(LABEL_SECTOR as u64 * SECTOR_SIZE as u64))?;
-        f.write_all(&mut sec_buf)?;
+        f.write_all(&sec_buf)?;
 
         for area in &pvh.metadata_areas {
             let new_rl = RawLocn {
@@ -385,7 +385,7 @@ impl PvHeader {
         assert!(area.size as usize > MDA_HEADER_SIZE);
         file.seek(SeekFrom::Start(area.offset))?;
         let mut hdr = [0u8; MDA_HEADER_SIZE];
-        file.read(&mut hdr)?;
+        file.read_exact(&mut hdr)?;
 
         if LittleEndian::read_u32(&hdr[..4]) != crc32_calc(&hdr[4..MDA_HEADER_SIZE]) {
             return Err(Error::Io(io::Error::new(
@@ -481,11 +481,11 @@ impl PvHeader {
             let first_read = min(pvarea.size - rl.offset, rl.size) as usize;
 
             f.seek(SeekFrom::Start(pvarea.offset + rl.offset))?;
-            f.read(&mut text[..first_read])?;
+            f.read_exact(&mut text[..first_read])?;
 
             if first_read != rl.size as usize {
                 f.seek(SeekFrom::Start(pvarea.offset + MDA_HEADER_SIZE as u64))?;
-                f.read(&mut text[rl.size as usize - first_read..])?;
+                f.read_exact(&mut text[rl.size as usize - first_read..])?;
             }
 
             if rl.checksum != crc32_calc(&text) {

--- a/src/pvlabel.rs
+++ b/src/pvlabel.rs
@@ -260,7 +260,7 @@ impl PvHeader {
         let label_header = LabelHeader::from_buf(&buf)?;
         let pvheader = Self::from_buf(&buf[label_header.offset as usize..], path)?;
 
-        return Ok(pvheader);
+        Ok(pvheader)
     }
 
     fn blkdev_size(file: &File) -> Result<u64> {
@@ -269,7 +269,7 @@ impl PvHeader {
         let mut val: u64 = 0;
 
         match unsafe { ioctl::read_into(file.as_raw_fd(), op, &mut val) } {
-            Err(_) => return Err(Error::Io(io::Error::last_os_error())),
+            Err(_) => Err(Error::Io(io::Error::last_os_error())),
             Ok(_) => Ok(val),
         }
     }
@@ -498,7 +498,7 @@ impl PvHeader {
             return buf_to_textmap(&text);
         }
 
-        return Err(Error::Io(io::Error::new(Other, "No valid metadata found")));
+        Err(Error::Io(io::Error::new(Other, "No valid metadata found")))
     }
 
     /// Write the given metadata to all active metadata areas in the PV.

--- a/src/pvlabel.rs
+++ b/src/pvlabel.rs
@@ -111,7 +111,7 @@ struct PvAreaIter<'a> {
     area: &'a [u8],
 }
 
-fn iter_pv_area<'a>(buf: &'a [u8]) -> PvAreaIter<'a> {
+fn iter_pv_area(buf: &[u8]) -> PvAreaIter {
     PvAreaIter { area: buf }
 }
 
@@ -147,7 +147,7 @@ struct RawLocnIter<'a> {
     area: &'a [u8],
 }
 
-fn iter_raw_locn<'a>(buf: &'a [u8]) -> RawLocnIter<'a> {
+fn iter_raw_locn(buf: &[u8]) -> RawLocnIter {
     RawLocnIter { area: buf }
 }
 

--- a/src/pvlabel.rs
+++ b/src/pvlabel.rs
@@ -73,8 +73,8 @@ impl LabelHeader {
 
                 return Ok(LabelHeader {
                     id: String::from_utf8_lossy(&sec_buf[..8]).into_owned(),
-                    sector: sector,
-                    crc: crc,
+                    sector,
+                    crc,
                     // switch from "offset from label" to "offset from start", more convenient.
                     offset: LittleEndian::read_u32(&sec_buf[20..24])
                         + (x * SECTOR_SIZE as usize) as u32,
@@ -128,7 +128,7 @@ impl<'a> Iterator for PvAreaIter<'a> {
             self.area = &self.area[16..];
             Some(PvArea {
                 offset: off,
-                size: size,
+                size,
             })
         }
     }
@@ -166,8 +166,8 @@ impl<'a> Iterator for RawLocnIter<'a> {
             self.area = &self.area[24..];
             Some(RawLocn {
                 offset: off,
-                size: size,
-                checksum: checksum,
+                size,
+                checksum,
                 ignored: (flags & 1) > 0,
             })
         }
@@ -240,8 +240,8 @@ impl PvHeader {
         Ok(PvHeader {
             uuid: hyphenate_uuid(&buf[..ID_LEN]),
             size: LittleEndian::read_u64(&buf[ID_LEN..ID_LEN + 8]),
-            ext_version: ext_version,
-            ext_flags: ext_flags,
+            ext_version,
+            ext_flags,
             data_areas: da_vec,
             metadata_areas: md_vec,
             bootloader_areas: ba_vec,

--- a/src/pvlabel.rs
+++ b/src/pvlabel.rs
@@ -35,8 +35,7 @@ use crate::{Error, Result};
 
 const LABEL_SCAN_SECTORS: usize = 4;
 const ID_LEN: usize = 32;
-const MDA_MAGIC: &[u8] =
-    b"\x20\x4c\x56\x4d\x32\x20\x78\x5b\x35\x41\x25\x72\x30\x4e\x2a\x3e";
+const MDA_MAGIC: &[u8] = b"\x20\x4c\x56\x4d\x32\x20\x78\x5b\x35\x41\x25\x72\x30\x4e\x2a\x3e";
 const LABEL_SIZE: usize = 32;
 const LABEL_SECTOR: usize = 1;
 pub const SECTOR_SIZE: usize = 512;
@@ -126,10 +125,7 @@ impl<'a> Iterator for PvAreaIter<'a> {
             None
         } else {
             self.area = &self.area[16..];
-            Some(PvArea {
-                offset: off,
-                size,
-            })
+            Some(PvArea { offset: off, size })
         }
     }
 }

--- a/src/vg.rs
+++ b/src/vg.rs
@@ -117,19 +117,19 @@ impl VG {
     pub fn from_textmap(name: &str, map: &LvmTextMap) -> Result<VG> {
         let err = || Error::Io(io::Error::new(Other, "vg textmap parsing error"));
 
-        let id = map.string_from_textmap("id").ok_or(err())?;
-        let seqno = map.i64_from_textmap("seqno").ok_or(err())?;
-        let format = map.string_from_textmap("format").ok_or(err())?;
-        let extent_size = map.i64_from_textmap("extent_size").ok_or(err())?;
-        let max_lv = map.i64_from_textmap("max_lv").ok_or(err())?;
-        let max_pv = map.i64_from_textmap("max_pv").ok_or(err())?;
-        let metadata_copies = map.i64_from_textmap("metadata_copies").ok_or(err())?;
+        let id = map.string_from_textmap("id").ok_or_else(err)?;
+        let seqno = map.i64_from_textmap("seqno").ok_or_else(err)?;
+        let format = map.string_from_textmap("format").ok_or_else(err)?;
+        let extent_size = map.i64_from_textmap("extent_size").ok_or_else(err)?;
+        let max_lv = map.i64_from_textmap("max_lv").ok_or_else(err)?;
+        let max_pv = map.i64_from_textmap("max_pv").ok_or_else(err)?;
+        let metadata_copies = map.i64_from_textmap("metadata_copies").ok_or_else(err)?;
 
         let status = status_from_textmap(map)?;
 
         let flags: Vec<_> = map
             .list_from_textmap("flags")
-            .ok_or(err())?
+            .ok_or_else(err)?
             .iter()
             .filter_map(|item| match item {
                 &Entry::String(ref x) => Some(x.clone()),
@@ -150,7 +150,7 @@ impl VG {
         //
         let str_to_pv = map
             .textmap_from_textmap("physical_volumes")
-            .ok_or(err())
+            .ok_or_else(err)
             .and_then(|tm| {
                 let mut ret_map = BTreeMap::new();
 
@@ -325,7 +325,7 @@ impl VG {
 
         self.pvs
             .remove(&dev)
-            .ok_or(Error::Io(io::Error::new(Other, "Could not remove PV")))?;
+            .ok_or_else(|| Error::Io(io::Error::new(Other, "Could not remove PV")))?;
 
         self.commit()
     }
@@ -428,7 +428,7 @@ impl VG {
             let meta_lv = self
                 .lvs
                 .get_mut(thin_meta)
-                .ok_or(Error::Io(io::Error::new(Other, "Meta LV not found")))?;
+                .ok_or_else(|| Error::Io(io::Error::new(Other, "Meta LV not found")))?;
             let new_name = format!("{}_tmeta", name);
 
             dm.device_rename(&DmName::new(name)?, &DevId::Name(DmName::new(&new_name)?))?;
@@ -439,7 +439,7 @@ impl VG {
             let _data_lv = self
                 .lvs
                 .get(thin_data)
-                .ok_or(Error::Io(io::Error::new(Other, "Data LV not found")))?;
+                .ok_or_else(|| Error::Io(io::Error::new(Other, "Data LV not found")))?;
             let new_name = format!("{}_tdata", name);
             dm.device_rename(&DmName::new(name)?, &DevId::Name(DmName::new(&new_name)?))?;
         }

--- a/src/vg.rs
+++ b/src/vg.rs
@@ -256,12 +256,9 @@ impl VG {
             // (It's the only textmap.)
             let mut vg_name = Cow::Borrowed("<unknown>");
             for (key, value) in metadata {
-                match value {
-                    Entry::TextMap(_) => {
-                        vg_name = Cow::Owned(key);
-                        break;
-                    }
-                    _ => {}
+                if let Entry::TextMap(_) = value {
+                    vg_name = Cow::Owned(key);
+                    break;
                 }
             }
 

--- a/src/vg.rs
+++ b/src/vg.rs
@@ -132,7 +132,7 @@ impl VG {
             .ok_or_else(err)?
             .iter()
             .filter_map(|item| match item {
-                &Entry::String(ref x) => Some(x.clone()),
+                Entry::String(ref x) => Some(x.clone()),
                 _ => None,
             })
             .collect();
@@ -156,7 +156,7 @@ impl VG {
 
                 for (key, value) in tm {
                     match value {
-                        &Entry::TextMap(ref pv_dict) => {
+                        Entry::TextMap(ref pv_dict) => {
                             ret_map.insert(key.to_string(), pv::from_textmap(pv_dict)?);
                         }
                         _ => return Err(Error::Io(io::Error::new(Other, "expected PV textmap"))),
@@ -173,7 +173,7 @@ impl VG {
 
                 for (key, value) in tm {
                     match value {
-                        &Entry::TextMap(ref lv_dict) => {
+                        Entry::TextMap(ref lv_dict) => {
                             ret_map.insert(
                                 key.to_string(),
                                 lv::from_textmap(key, lv_dict, &str_to_pv)?,

--- a/src/vg.rs
+++ b/src/vg.rs
@@ -268,10 +268,8 @@ impl VG {
             )));
         }
 
-        let da = pvh.data_areas.get(0).ok_or(Error::Io(io::Error::new(
-            Other,
-            "Could not find data area in PV",
-        )))?;
+        let da = pvh.data_areas.get(0).ok_or_else(|| Error::Io(io::Error::new(
+                    Other, "Could not find data area in PV", )))?;
 
         // figure out how many extents fit in the PV's data area
         // pe_start aligned to extent size
@@ -562,7 +560,7 @@ impl VG {
             for (device, start, len) in lv::used_areas(lv) {
                 used_map
                     .entry(device)
-                    .or_insert(BTreeMap::new())
+                    .or_insert_with(BTreeMap::new)
                     .insert(start, len);
             }
         }
@@ -592,7 +590,7 @@ impl VG {
                 if prev_end < *start {
                     free_map
                         .entry(dev)
-                        .or_insert(BTreeMap::new())
+                        .or_insert_with(BTreeMap::new)
                         .insert(prev_end, start - prev_end);
                 }
                 start + len

--- a/src/vg.rs
+++ b/src/vg.rs
@@ -220,7 +220,7 @@ impl VG {
         for (lvname, dev, _) in dm_devices {
             let lvname = String::from_utf8_lossy(lvname.as_bytes()).into_owned();
             if let Some(lv) = vg.lvs.get_mut(&lvname) {
-                lv.device = Some(dev.into());
+                lv.device = Some(dev);
             }
         }
 
@@ -613,7 +613,7 @@ impl VG {
 
     /// Returns a list of PV Devices that make up the VG.
     pub fn pv_list(&self) -> Vec<Device> {
-        self.pvs.keys().map(|key| *key).collect()
+        self.pvs.keys().copied().collect()
     }
 
     /// Returns a reference to the PV matching the Device.
@@ -623,7 +623,7 @@ impl VG {
 
     /// Returns a list of the names of LVs in the VG.
     pub fn lv_list(&self) -> Vec<String> {
-        self.lvs.keys().map(|key| key.clone()).collect()
+        self.lvs.keys().cloned().collect()
     }
 
     /// Returns a reference to the LV matching the name.

--- a/src/vg.rs
+++ b/src/vg.rs
@@ -662,16 +662,16 @@ fn to_textmap(vg: &VG) -> LvmTextMap {
 
     map.insert(
         "status".to_string(),
-        Entry::List(Box::new(
+        Entry::List(
             vg.status.iter().map(|x| Entry::String(x.clone())).collect(),
-        )),
+        ),
     );
 
     map.insert(
         "flags".to_string(),
-        Entry::List(Box::new(
+        Entry::List(
             vg.flags.iter().map(|x| Entry::String(x.clone())).collect(),
-        )),
+        ),
     );
 
     map.insert(

--- a/src/vg.rs
+++ b/src/vg.rs
@@ -64,7 +64,7 @@ pub struct VG {
 impl VG {
     /// Create a Volume Group from one or more PVs.
     pub fn create(name: &str, pv_paths: Vec<&Path>) -> Result<VG> {
-        if pv_paths.len() == 0 {
+        if pv_paths.is_empty() {
             return Err(Error::Io(io::Error::new(
                 Other,
                 "One or more paths to PVs required",

--- a/src/vg.rs
+++ b/src/vg.rs
@@ -531,7 +531,7 @@ impl VG {
             "creation_time".to_string(),
             Entry::Number(now().to_timespec().sec),
         );
-        disk_map.insert(self.name.clone(), Entry::TextMap(Box::new(map.clone())));
+        disk_map.insert(self.name.clone(), Entry::TextMap(Box::new(map)));
 
         // TODO: atomicity of updating pvs, metad, dm
         for pv in self.pvs.values() {

--- a/src/vg.rs
+++ b/src/vg.rs
@@ -198,14 +198,14 @@ impl VG {
             id: id.to_string(),
             seqno: seqno as u64,
             format: format.to_string(),
-            status: status,
-            flags: flags,
+            status,
+            flags,
             extent_size: extent_size as u64,
             max_lv: max_lv as u64,
             max_pv: max_pv as u64,
             metadata_copies: metadata_copies as u64,
-            pvs: pvs,
-            lvs: lvs,
+            pvs,
+            lvs,
         };
 
         // let dm_devices = {
@@ -447,7 +447,7 @@ impl VG {
 
         let segment = Box::new(segment::ThinpoolSegment {
             start_extent: 0,
-            extent_count: extent_count,
+            extent_count,
             metadata_lv: thin_meta.to_string(),
             data_lv: thin_data.to_string(),
             transaction_id: 1,

--- a/src/vg.rs
+++ b/src/vg.rs
@@ -268,8 +268,10 @@ impl VG {
             )));
         }
 
-        let da = pvh.data_areas.get(0).ok_or_else(|| Error::Io(io::Error::new(
-                    Other, "Could not find data area in PV", )))?;
+        let da = pvh
+            .data_areas
+            .get(0)
+            .ok_or_else(|| Error::Io(io::Error::new(Other, "Could not find data area in PV")))?;
 
         // figure out how many extents fit in the PV's data area
         // pe_start aligned to extent size
@@ -658,16 +660,12 @@ fn to_textmap(vg: &VG) -> LvmTextMap {
 
     map.insert(
         "status".to_string(),
-        Entry::List(
-            vg.status.iter().map(|x| Entry::String(x.clone())).collect(),
-        ),
+        Entry::List(vg.status.iter().map(|x| Entry::String(x.clone())).collect()),
     );
 
     map.insert(
         "flags".to_string(),
-        Entry::List(
-            vg.flags.iter().map(|x| Entry::String(x.clone())).collect(),
-        ),
+        Entry::List(vg.flags.iter().map(|x| Entry::String(x.clone())).collect()),
     );
 
     map.insert(

--- a/src/vg.rs
+++ b/src/vg.rs
@@ -341,13 +341,14 @@ impl VG {
                     }
                 }
             }
-            if contig_area.is_none() {
+
+            if let Some(contig) = contig_area {
+                contig
+            } else {
                 return Err(Error::Io(io::Error::new(
                     Other,
                     "no contiguous area for new LV",
                 )));
-            } else {
-                contig_area.unwrap()
             }
         };
 


### PR DESCRIPTION
I was looking over code base and discovered that it wouldn't build without

```diff
diff --git a/src/core/device.rs b/src/core/device.rs
index 5885394..487d971 100644
--- a/src/core/device.rs
+++ b/src/core/device.rs
@@ -15,7 +15,7 @@ use crate::{
 /// A struct containing the device's major and minor numbers
 ///
 /// Also allows conversion to/from a single 64bit dev_t value.
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Device {
     /// Device major number
     pub major: u32,
```
not sure how code builds without this change to `devicemapper-rs`.

After I got it to build, I ran clippy and addressed the warnings and formatted my changes.